### PR TITLE
#387 Fixed typo: Changed artefact to artifact

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+* @dirkwall @AloisReitbauer @danielkhan

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ kubectl apply -f slack-service.yaml
 Expected output:
 ```
 service.serving.knative.dev/slack-service created
-subscription.eventing.knative.dev/slack-subscription-new-artefact created
+subscription.eventing.knative.dev/slack-subscription-new-artifact created
 subscription.eventing.knative.dev/slack-subscription-configuration-changed created
 subscription.eventing.knative.dev/slack-subscription-deployment-finished created
 subscription.eventing.knative.dev/slack-subscription-tests-finished created
@@ -61,7 +61,7 @@ slack-subscription-configuration-changed        True
 slack-subscription-deployment-finished          True
 slack-subscription-evaluation-done              True
 slack-subscription-keptn                        True
-slack-subscription-new-artefact                 True
+slack-subscription-new-artifact                 True
 slack-subscription-tests-finished               True
 $
 ```

--- a/releasenotes/releasenotes_0.1.0.md
+++ b/releasenotes/releasenotes_0.1.0.md
@@ -1,0 +1,7 @@
+# Release Notes 0.1.0
+
+## New Features
+
+## Fixed Issues
+
+## Known Limitations

--- a/releasenotes/releasenotes_0.1.1.md
+++ b/releasenotes/releasenotes_0.1.1.md
@@ -1,0 +1,7 @@
+# Release Notes 0.1.1
+
+## New Features
+
+## Fixed Issues
+
+## Known Limitations

--- a/releasenotes/releasenotes_0.1.2.md
+++ b/releasenotes/releasenotes_0.1.2.md
@@ -1,0 +1,7 @@
+# Release Notes 0.1.2
+
+## New Features
+
+## Fixed Issues
+
+## Known Limitations

--- a/releasenotes/releasenotes_develop.md
+++ b/releasenotes/releasenotes_develop.md
@@ -1,7 +1,6 @@
 # Release Notes x.x.x
 
 ## New Features
-- 
 
 ## Fixed Issues
 - Fixed typo: Changed _art**e**fact_ to _art**i**fact_ [#387](https://github.com/keptn/keptn/issues/387)

--- a/releasenotes/releasenotes_develop.md
+++ b/releasenotes/releasenotes_develop.md
@@ -1,0 +1,9 @@
+# Release Notes x.x.x
+
+## New Features
+- 
+
+## Fixed Issues
+- Fixed typo: Changed _art**e**fact_ to _art**i**fact_ [#387](https://github.com/keptn/keptn/issues/387)
+
+## Known Limitations

--- a/slack-service.bal
+++ b/slack-service.bal
@@ -61,14 +61,14 @@ type KeptnEvent record {
     KeptnData data;
 };
 
-const NEW_ARTEFACT = "sh.keptn.events.new-artefact";
+const NEW_ARTIFACT = "sh.keptn.events.new-artifact";
 const CONFIGURATION_CHANGED = "sh.keptn.events.configuration-changed";
 const DEPLOYMENT_FINISHED = "sh.keptn.events.deployment-finished";
 const TESTS_FINISHED = "sh.keptn.events.tests-finished";
 const EVALUATION_DONE = "sh.keptn.events.evaluation-done";
 const PROBLEM = "sh.keptn.events.problem";
-type KEPTN_EVENT NEW_ARTEFACT|CONFIGURATION_CHANGED|DEPLOYMENT_FINISHED|TESTS_FINISHED|EVALUATION_DONE|PROBLEM;
-type KEPTN_CD_EVENT NEW_ARTEFACT|CONFIGURATION_CHANGED|DEPLOYMENT_FINISHED|TESTS_FINISHED|EVALUATION_DONE;
+type KEPTN_EVENT NEW_ARTIFACT|CONFIGURATION_CHANGED|DEPLOYMENT_FINISHED|TESTS_FINISHED|EVALUATION_DONE|PROBLEM;
+type KEPTN_CD_EVENT NEW_ARTIFACT|CONFIGURATION_CHANGED|DEPLOYMENT_FINISHED|TESTS_FINISHED|EVALUATION_DONE;
 
 const IMAGE_URL = "https://via.placeholder.com/150";
 
@@ -136,7 +136,7 @@ function generateMessage(json payload) returns @untainted json {
         string eventType = event.^"type";
 
         if (eventType is KEPTN_EVENT) {
-            // new-artefact, configuration-changed, deployment-finished, tests-finished, evaluation-done
+            // new-artifact, configuration-changed, deployment-finished, tests-finished, evaluation-done
             if (eventType is KEPTN_CD_EVENT) {
                 string knownEventType = getUpperCaseEventTypeFromEvent(event);
                 text += "*" + knownEventType + "*\n";
@@ -144,7 +144,7 @@ function generateMessage(json payload) returns @untainted json {
                 text += "Service:\t`" + event.data.^"service" + "`\n";
                 text += "Image:  \t`" + event.data.image + ":" + event.data.tag + "`\n";
                 // configuration-changed, deployment-finished, tests-finished, evaluation-done
-                if (!(eventType is NEW_ARTEFACT)) {
+                if (!(eventType is NEW_ARTIFACT)) {
                     text += "Stage:   \t`" + event.data.stage + "`\n";
                 }
 
@@ -297,11 +297,11 @@ function testGetUpperCaseEventTypeFromEvent() {
         datacontenttype: "",
         shkeptncontext: "",
         data: {},
-        ^"type": "something.bla.bla.new-artefact"
+        ^"type": "something.bla.bla.new-artifact"
     };
 
     string eventType = getUpperCaseEventTypeFromEvent(event);
-    test:assertEquals(eventType, "NEW ARTEFACT");
+    test:assertEquals(eventType, "NEW ARTIFACT");
 }
 
 @test:Config

--- a/slack-service.yaml
+++ b/slack-service.yaml
@@ -22,13 +22,13 @@ spec:
 apiVersion: eventing.knative.dev/v1alpha1
 kind: Subscription
 metadata:
-  name: slack-subscription-new-artefact
+  name: slack-subscription-new-artifact
   namespace: keptn
 spec:
   channel:
     apiVersion: eventing.knative.dev/v1alpha1
     kind: Channel
-    name: new-artefact
+    name: new-artifact
   subscriber:
     ref:
       apiVersion: serving.knative.dev/v1alpha1


### PR DESCRIPTION
This PR ensures a consistent use of the word artifact instead of artefact across all keptn repositories.